### PR TITLE
fixes #111 - allows minimum clade standard as a clade specifier for c…

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -50,6 +50,7 @@ class Submission < ActiveRecord::Base
   
   
   CrownSpecifiers = [
+      Submission::MinimumCladeStandard,
       Submission::MinimumCrownClade,
       Submission::MaximumCrownClade,
       Submission::ApomorphyModifiedCrownClade


### PR DESCRIPTION
Allows minimum clade standard as a clade specifier for crown based definitions. Example, can now choose _Carnivora_ as a clade specifier for _Pan-carnivora_