### PR TITLE
[PHY-19] displays definitional citation in summary view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,19 +103,133 @@ module ApplicationHelper
         end)
   end
 
+  def display_citation citation
+    if has_authors? citation[:authors]
+      return display_citation_with_authors citation
+    end
 
+    display_citation_with_editors citation
+  end
 
-  def display_authors authors_array
-    if authors_array.count == 0
+  def display_citation_with_editors citation
+    editors = editor_string citation[:editors]
+    pages = get_citation_pages citation
+    "#{editors}. (#{citation[:year]}) #{citation[:title]}. #{citation[:publisher]}, #{citation[:city]}. #{pages}"
+  end
+
+  def display_citation_with_authors citation
+    authors = author_string citation[:authors]
+    if has_authors? citation[:editors]
+      editors = author_string citation[:editors]
+    else
+      editors = ""
+    end
+    pages = get_citation_pages citation
+    "#{authors}. (#{citation[:year]}) #{citation[:title]}. #{editors} #{citation[:publisher]}, #{citation[:city]}. #{pages}"
+  end
+
+  def get_citation_pages citation
+    pages = citation[:pages]
+    if pages.nil? || pages.empty?
       return ""
+    end
+
+    if pages.include? "-"
+      return "(pp. #{pages})"
+    end
+
+    "(p. #{pages})"
+  end
+
+  def author_string editors_array
+    count = editors_array.count
+    out = ""
+
+    editors = editors_array.each_with_index.map do |auth, i|
+      last_name = auth[:last_name]
+      middle_name = auth[:middle_name]
+      first_name = auth[:first_name]
+      if i == 0
+        return "#{last_name}, #{citation_first_name(first_name)}#{citation_middle_name(middle_name)}"
+      end
+      return "#{citation_first_name(first_name)}#{citation_middle_name(middle_name)} #{last_name}"
+    end
+
+    last_index = count - 1
+
+    if last_index == 0
+      return editors.first
+    end
+
+    editors.each_with_index do |ed, i|
+      if i == last_index
+        out += "and #{ed}"
+      else
+        out += "#{ed}, "
+      end
+    end
+    out
+  end
+
+  def editor_string editors_array
+    count = editors_array.count
+    if (count == 1)
+      suffix = "(Ed.)"
+    else
+      suffix = "(Eds.)"
+    end
+    out = ""
+    editors = editors_array.each_with_index.map do |auth, i|
+      last_name = auth[:last_name]
+      middle_name = auth[:middle_name]
+      first_name = auth[:first_name]
+      if i == 0
+        return "#{last_name}, #{citation_first_name(first_name)}#{citation_middle_name(middle_name)}"
+      end
+      return "#{citation_first_name(first_name)}#{citation_middle_name(middle_name)} #{last_name}"
+    end
+    last_index = count - 1
+    editors.each_with_index do |ed, i|
+      if i == last_index
+        out += "and #{ed}"
+      else
+        out += "#{ed}, "
+      end
+    end
+    "#{out} #{suffix}"
+  end
+
+  def citation_middle_name middle_name
+    if middle_name.empty?
+      return ""
+    end
+    return middle_name.slice(0) + "."
+  end
+
+  def citation_first_name first_name
+    if first_name.empty?
+      return ""
+    end
+    return first_name.slice(0) + "."
+  end
+
+  def has_authors? authors_array
+    if authors_array.count == 0
+      return false
     end
 
     if authors_array.count == 1
       author = authors_array.first
-      if (author[:first_name].empty? && author[:last_name].empty?)
-        return ""
+      if author[:first_name].empty? && author[:last_name].empty?
+        return false
       end
     end
+
+    true
+  end
+
+  def display_authors authors_array
+    return "" if !has_authors? authors_array
 
     authors = authors_array.map do |auth|
       "#{auth[:last_name]}. #{auth[:first_name]} #{auth[:middle_name]}".strip

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,6 +1,9 @@
 module SubmissionsHelper
 
   def name_string_formatted
+    if @sub.name_string.nil?
+      return ""
+    end
     raw @sub.name_string.sub(@sub.name, "<em>#{@sub.name}</em>")
   end
 
@@ -30,6 +33,5 @@ module SubmissionsHelper
                options_from_collection_for_select(Submission.crown_specifiers, :name_id, :name_and_clade_type),
                include_blank: "Please make a selection",
                data: { bind: "value: specifier_crown" })
-
   end
 end

--- a/app/views/shared/_cladename_view.html.haml
+++ b/app/views/shared/_cladename_view.html.haml
@@ -32,6 +32,7 @@
             %p Establish under PhyloCode:
         %tr  
           %td= @sub.establish ? 'yes' : 'no'
+      = render :partial => 'shared/submission_citation', locals: {citation: @sub.citations['definitional'], citation_type: "Definitional"}
       %tr
         %td.name
           %p Pre-existing name:
@@ -47,31 +48,8 @@
           %td.name
             %p Pre-existing Author(s):
         %tr  
-          %td= @sub.preexisting_authors      
-        %tr  
-          %td.name
-            %p Pre-existing Reference:
-        %tr
-          %td
-            .accordion
-              %h3 
-                &nbsp;
-                = @sub.citations['preexisting']['title']
-              %div
-                %table
-                  -['citation_type','title','authors'].each do |cit|
-                    %tr
-                      %td
-                        %span
-                          %span{:style => 'font-weight:bold;'}= cit.humanize + ': '
-                          = format_output(cit,@sub.citations['preexisting'].delete(cit))
-                  -attachment_prepare(@sub.citations['preexisting']).each do |key,val|
-                    -if !val.blank?
-                      %tr
-                        %td
-                          %span
-                            %span{:style => 'font-weight:bold;'}= key.humanize + ': '
-                            = format_output(key,val)
+          %td= @sub.preexisting_authors
+        = render :partial => 'shared/submission_citation', locals: {citation: @sub.citations['preexisting'], citation_type: "Pre-existing"}
       %tr
         %td.name
           %p Comments:

--- a/app/views/shared/_submission_citation.haml
+++ b/app/views/shared/_submission_citation.haml
@@ -1,0 +1,19 @@
+- unless citation.nil?
+  %tr
+    %td.name
+      %p= "#{citation_type} Citation"
+  %tr
+    %td
+      .accordion
+        %h3
+          &nbsp;
+          = display_citation citation
+        %div
+          %table
+            -['citation_type', 'title', 'authors', 'editors', 'publisher', 'city', 'pages', 'doi'].each do |cit|
+              - if (!citation[cit].nil? && !citation[cit].empty?) || (citation[cit].is_a?(Array) && has_authors?(citation[cit]))
+                %tr
+                  %td
+                    %span
+                      %span{style: "font-weight: bold;"}= cit.humanize + ': '
+                      = format_output(cit, citation.delete(cit))


### PR DESCRIPTION
Fixes https://regnum.atlassian.net/browse/PHY-19

> The definitional citation that I believe in entered when a name is created (first tab) is not showing in the summary view, when a user clicks on a name in the search box to view. That's critical information that needs to be displayed.