### PR TITLE
PHY-26 adds "None" option to dropdown list for preexisting code

### DIFF
--- a/app/views/cladename/_clade_name_tab.html.erb
+++ b/app/views/cladename/_clade_name_tab.html.erb
@@ -87,6 +87,7 @@
             <div class="form-group col-sm-12">
               <label for="new_preexisting_code">Code:</label>
               <select data-bind="value: preexisting_code" name="cladename[preexisting_code]" id="new_preexisting_code" class="value-input form-control">
+                <option value="None">None</option>
                 <option value="ICBN">ICN - the botanical code</option>
                 <option value="ICZN">ICZN - the zoological code</option>
                 <option value="ICNB">ICNB - the bacterial code</option>


### PR DESCRIPTION
https://regnum.atlassian.net/browse/PHY-26

> In the Pre-existing names, when we select a pre-existing Code of Nomenclature (e.g., ICZN, ICN, etc.) please add "None" on top of the menu.