### PR TITLE
[CD] PHY-27 display pre-existing authors on view popup of main/search…

### DIFF
--- a/app/views/shared/_cladename_view.html.haml
+++ b/app/views/shared/_cladename_view.html.haml
@@ -46,7 +46,7 @@
           %td.name
             %p Pre-existing Author(s):
         %tr  
-          %td= @sub.preexisting_authors
+          %td= display_authors @sub.citations['preexisting']['authors']
         = render :partial => 'shared/submission_citation', locals: {citation: @sub.citations['preexisting'], citation_type: "Pre-existing"}
       %tr
         %td.name


### PR DESCRIPTION
fixes https://regnum.atlassian.net/browse/PHY-27

# Description
The information in the Pre-existing author field is not showing in the view window. The field is, but no information is displayed.