### PR TITLE
[CD] PHY-29 fixes capitalization but defaulting to what is entered by…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,7 +99,7 @@ module ApplicationHelper
             end
             obj[:name]
           else
-            val.humanize
+            val
         end)
   end
 


### PR DESCRIPTION
https://regnum.atlassian.net/browse/PHY-29

### Description

When viewing a record - for example Biota -  in the first tab (Clade name) and click on the "definitional citation" to get more information, the information is displayed incorrectly: 1) the Publisher is displayed as Crc press, boca raton, fl" instead of CRC Press, Boca Raton, FL" as entered in the database (Somewhere - but can’t find it right now - also ICZN (or any other code, I guess) is displayed in small caps. This was pointed out to me).

    Just checked again, this change in caps is true pretty much everywhere.

    2) Not all filled fields in the citations are displayed (e.g., authors, book section title…)